### PR TITLE
Ensure contact form isn't imported if it already exists

### DIFF
--- a/src/Umbraco.SampleSite/FormsInstallationHelper.cs
+++ b/src/Umbraco.SampleSite/FormsInstallationHelper.cs
@@ -14,9 +14,9 @@ namespace Umbraco.SampleSite
     public class FormsInstallationHelper
     {
         private readonly ServiceContext _services;
-
         private static readonly Regex PreInstallContactFormHtmlPattern = new Regex(@"@Umbraco\.RenderMacro\(\""renderUmbracoForm\""\,[\.\w\{\}\=\(\)\s]+\)", RegexOptions.Compiled);
         private static string PreInstallContactFormHtml = "@Umbraco.RenderMacro(\"renderUmbracoForm\", new { FormGuid = Model.ContactForm.ToString(), ExcludeScripts=\"0\" })";
+        private static Guid ContactFormId = new Guid("adf160f1-39f5-44c0-b01d-9e2da32bf093");
 
         private static readonly Regex PostInstallContactFormHtmlPattern = new Regex(@"\<p class=\""compat-msg\""\>.+?\<\/p\>", RegexOptions.Compiled | RegexOptions.Singleline);
         private static string PostInstallContactFormHtml = @"<p class=""compat-msg"">
@@ -30,7 +30,7 @@ namespace Umbraco.SampleSite
 
         private const string DocTypeAlias = "contact";
         private const string PropertyAlias = "contactForm";
-        private const string TemplateAlias = "contact";
+        private const string TemplateAlias = "contact";        
         private const string FormDataTypeAlias = "UmbracoForms.FormPicker";
         private const string FormsMacroAlias = "renderUmbracoForm";
 
@@ -159,7 +159,7 @@ namespace Umbraco.SampleSite
                         contactView.Content = templateContent;
                         fileService.SaveTemplate(contactView);
                     }
-                }
+                }   
 
                 CreateStarterKitForm();
             }
@@ -183,10 +183,7 @@ namespace Umbraco.SampleSite
 
             var formsStorageType = formsAssembly.GetType("Umbraco.Forms.Core.Data.Storage.IFormStorage");
             if (formsStorageType == null) return;
-
-            //this is the form id that is installed
-            var formId = new Guid("adf160f1-39f5-44c0-b01d-9e2da32bf093");
-
+            
             //create a FormsStorage instance
             object formsStorageInstance;
             try
@@ -202,7 +199,7 @@ namespace Umbraco.SampleSite
 
             try
             {
-                var form = CallMethod(formsStorageInstance, "GetForm", formId);
+                var form = CallMethod(formsStorageInstance, "GetForm", ContactFormId);
                 if (form == null) return;
 
                 var deleteResult = CallMethod(formsStorageInstance, "DeleteForm", form);
@@ -262,6 +259,22 @@ namespace Umbraco.SampleSite
                 Current.Logger.Error<FormsInstallationHelper>(ex, "Unable to get instance of Umbraco.Forms.Core.Data.Storage.IFormStorage from Container");
 
                 //If we cannot create it then there's nothing we can do
+                return;
+            }
+
+            // If the form already exists - skip out instead of trying to import a duplicate.
+            try
+            {
+                var existingForm = CallMethod(formsStorageInstance, "GetForm", ContactFormId);
+                if (existingForm != null)
+                {
+                    Current.Logger.Info<FormsInstallationHelper>("Skipped creating form - it already exists.");
+                    return;
+                }
+            }
+            catch (Exception ex)
+            {
+                Current.Logger.Error<FormsInstallationHelper>(ex, "Unable to call method GetForm on FormStorage");
                 return;
             }
 


### PR DESCRIPTION
Some of the install code is being run twice and while this is likely not correct either, I do not have the overview of what is causing this to happen - whether it is in the starterkit or in the way packages are handled.

To avoid regression problems related to trying to prevent this from running twice, I've instead made a check to ensure the contact form isn't imported as a duplicate if it already exists.

This has worked without any issues for quite some time due to a file simply being overwritten when a form was imported twice, but if Forms is configured to store forms in the database, this will now cause duplicate form entries to be added to the database.